### PR TITLE
Increment crowdai & jupyter versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.14.50
 botocore==1.9.3
-certifi==2018.1.18
+certifi==2018.4.16
 cffi==1.11.5
 colorama==0.3.7
 cycler==0.10.0
@@ -25,11 +25,11 @@ s3transfer==0.1.13
 scikit-image==0.13.1
 scipy==1.0.1
 six==1.11.0
-tqdm==4.19.9
-jupyter-client==5.1.0
+tqdm==4.23.2
+jupyter-client==5.2.3
 jupyter-console==5.2.0
-jupyter-core==4.3.0
+jupyter-core==4.4.0
 jupyter-repo2docker==0.5.0
 jupyterlab==0.27.0
 jupyterlab-launcher==0.4.0
-crowdai==1.0.18
+crowdai==1.0.20


### PR DESCRIPTION
* Set the versions for tqdm and certifi to match crowdai's requirements.txt
* Upgrade jupyter-client and jupyter-core to latest
* Other packages are out of date but don't cause warnings - not addressed in this PR